### PR TITLE
Easier output directory specification & Python3 support

### DIFF
--- a/global_temps_parser.py
+++ b/global_temps_parser.py
@@ -1,9 +1,15 @@
 import pandas as pd
 import os, io, requests
+from os.path import join
 from functools import reduce
 
 #Set to your working directory
-os.chdir('/Users/hausfath/Desktop/Climate Science/')
+cwd = os.getcwd()
+
+# Add additional path segments to reach download directory
+# e.g. join(cwd, 'downloads') or join(cwd, '..', 'download_here')
+download_dir = join(cwd)
+
 
 #File URLs
 gistemp_file = 'https://data.giss.nasa.gov/gistemp/tabledata_v3/GLB.Ts+dSST.csv'
@@ -105,4 +111,7 @@ def rebaseline(temps, start_year, end_year):
 
 
 combined_temps = combined_global_temps(start_year, end_year)
-combined_temps.to_csv('combined_temps_base_'+str(start_year)+'_to_'+str(end_year)+'.csv')
+path_out = join(download_dir,
+                'combined_temps_base_{}_to_{}.csv'.format(start_year,
+                                                          end_year))
+combined_temps.to_csv(path_out, index=False)

--- a/global_temps_parser.py
+++ b/global_temps_parser.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import os, io, requests
+from functools import reduce
 
 #Set to your working directory
 os.chdir('/Users/hausfath/Desktop/Climate Science/')


### PR DESCRIPTION
Proposing a couple changes.

1. Use `os.path.join` to select the output directory rather than hardcoding it. This makes it easier to use the same script across machines with different operating systems.
2. Import `reduce` from `functools` for Python3 support (#1)